### PR TITLE
Added the option to use /Assets folder relative paths to protoc

### DIFF
--- a/ProtobufUnityCompiler.cs
+++ b/ProtobufUnityCompiler.cs
@@ -48,11 +48,27 @@ public class ProtobufUnityCompiler : AssetPostprocessor {
         }
     }
 
-    public static string excPath
+    public static string rawExcPath
     {
         get
         {
             return EditorPrefs.GetString(prefProtocExecutable, "");
+        }
+        set
+        {
+            EditorPrefs.SetString(prefProtocExecutable, value);
+        }
+    }
+
+    public static string excPath
+    {
+        get
+        {
+            string ret = EditorPrefs.GetString(prefProtocExecutable, "");
+            if (ret.StartsWith(".."))
+                return Path.Combine(Application.dataPath, ret);
+            else
+                return ret;
         }
         set
         {
@@ -74,7 +90,7 @@ public class ProtobufUnityCompiler : AssetPostprocessor {
 
         EditorGUILayout.BeginHorizontal();
         EditorGUILayout.LabelField("Path to protoc", GUILayout.Width(100));
-        excPath = EditorGUILayout.TextField(excPath, GUILayout.ExpandWidth(true));
+        rawExcPath = EditorGUILayout.TextField(rawExcPath, GUILayout.ExpandWidth(true));
         EditorGUILayout.EndHorizontal();
 
         EditorGUILayout.Space();


### PR DESCRIPTION
Thanks for this great utlity btw.
This is a simple change to allow e.g. "../ProtoBuf/protoc" as the path to the protoc compiler rather than an absolute path. This is useful when you don't want everyone to have to install the compiler, just include it in the game repo relative to /Assets.
Nb. It has to live below /Assets or the code will attempt to compile the contents of the redist /include folder.
