### PR TITLE
Fix use of SettingsScope enum to avoid CS0117

### DIFF
--- a/ProtobufUnityCompiler.cs
+++ b/ProtobufUnityCompiler.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_EDITOR
+#if UNITY_EDITOR
 using System.Collections;
 using System.Collections.Generic;
 using UnityEditor;
@@ -79,8 +79,8 @@ public class ProtobufUnityCompiler : AssetPostprocessor {
 #if UNITY_2018_3_OR_NEWER
     private class ProtobufUnitySettingsProvider : SettingsProvider
     {
-        public ProtobufUnitySettingsProvider(string path, SettingsScopes scopes = SettingsScopes.Any) 
-        : base(path, scopes)
+        public ProtobufUnitySettingsProvider(string path, SettingsScope scope = SettingsScope.User)
+        : base(path, scope)
         { }
 
         public override void OnGUI(string searchContext)


### PR DESCRIPTION
As of Unity 2018.3, the SettingsProvider constructor expects an enum of SettingsScop**e** instead of the undocumented and internal SettingsScop**es**. "Any" is not a property of this enum, use "User" instead (https://docs.unity3d.com/2018.3/Documentation/ScriptReference/SettingsScope.html).

As seen in the documentation, you used the preferences panel for the setup of the Protobuf compiler. Respecting this, I chose SettingsScope.User over SettingsScope.Project.