### PR TITLE
Fixed error that happens if gRPC field in prefs is blank

### DIFF
--- a/Editor/ProtobufUnityCompiler.cs
+++ b/Editor/ProtobufUnityCompiler.cs
@@ -114,7 +114,7 @@ namespace E7.Protobuf
                 }
 
                 // Checking if the user has set valid path (there is probably a better way)
-                if (ProtoPrefs.grpcPath != "ProtobufUnity_GrpcPath" || ProtoPrefs.grpcPath != string.Empty)
+                if (ProtoPrefs.grpcPath != "ProtobufUnity_GrpcPath" && ProtoPrefs.grpcPath != string.Empty)
                     options += $" --grpc_out={outputPath} --plugin=protoc-gen-grpc={ProtoPrefs.grpcPath}";
                 //string combinedPath = string.Join(" ", optionFiles.Concat(new string[] { protoFileSystemPath }));
 


### PR DESCRIPTION
As is currently, the conditional that checks the gRPC path string is always true since the string is guaranteed to not be empty or the default value. This would cause issues when trying to compile if you don't have a gRPC path specified.